### PR TITLE
Reconnect portforward

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -170,7 +170,7 @@ func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespac
 
 	ready := make(chan bool)
 	wg.Add(1)
-	go pf.Start(ctx, wg, client, restConfig, pod, d, ready)
+	go pf.Start(ctx, wg, client, restConfig, pod, ready)
 	<-ready
 
 	wg.Add(1)
@@ -182,6 +182,5 @@ func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespac
 
 func shutdown(cancel context.CancelFunc, wg *sync.WaitGroup) {
 	cancel()
-	log.Debugf("waiting for sync group")
 	wg.Wait()
 }

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -159,7 +159,7 @@ func GetPodEvents(ctx context.Context, pod *apiv1.Pod, c *kubernetes.Clientset) 
 			}
 
 			if event.Type == "Normal" {
-				log.Debug(event.Message)
+				log.Debugf("kubernetes: %s", event.Message)
 			} else {
 				fmt.Println(Red("Kubernetes: "), event.Message)
 			}

--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	cndEnvNamespace  = "CND_KUBERNETES_NAMESPACE"
-	initSyncImageTag = "okteto/init-syncthing:0.4.0"
+	initSyncImageTag = "okteto/init-syncthing:0.4.1"
 	syncImageTag     = "okteto/syncthing:0.4.0"
 )
 

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -300,11 +300,9 @@ type addAPIKeyTransport struct {
 }
 
 type syncthingConnections struct {
-	Connections map[string]syncthingConnection `json:"connections,omitempty"`
-}
-
-type syncthingConnection struct {
-	Connected bool `json:"connected,omitempty"`
+	Connections map[string]struct {
+		Connected bool `json:"connected,omitempty"`
+	} `json:"connections,omitempty"`
 }
 
 //Monitor verifies that syncthing is not in a disconnected state. If so, it sends a message to the

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -1,0 +1,60 @@
+package syncthing
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshallResponse(t *testing.T) {
+	body := []byte(`{
+		"connections": {
+		  "ABKAVQF-RUO4CYO-FSC2VIP-VRX4QDA-TQQRN2J-MRDXJUC-FXNWP6N-S6ZSAAR": {
+			"address": "",
+			"at": "0001-01-01T00:00:00Z",
+			"clientVersion": "",
+			"connected": false,
+			"inBytesTotal": 0,
+			"outBytesTotal": 0,
+			"paused": false,
+			"type": ""
+		  },
+		  "ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU": {
+			"address": "[::1]:51761",
+			"at": "2019-01-27T02:45:20.406724-08:00",
+			"clientVersion": "v1.0.0",
+			"connected": true,
+			"inBytesTotal": 161,
+			"outBytesTotal": 181,
+			"paused": false,
+			"type": "tcp-client"
+		  }
+		},
+		"total": {
+		  "address": "",
+		  "at": "2019-01-27T02:45:20.406734-08:00",
+		  "clientVersion": "",
+		  "connected": false,
+		  "inBytesTotal": 161,
+		  "outBytesTotal": 181,
+		  "paused": false,
+		  "type": ""
+		}
+	  }`)
+
+	var conns syncthingConnections
+	if err := json.Unmarshal(body, &conns); err != nil {
+		t.Fatalf("%s\n%s", body, err)
+	}
+
+	if len(conns.Connections) == 0 {
+		t.Fatalf("didn't parse the connections")
+	}
+
+	if _, ok := conns.Connections["ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"]; !ok {
+		t.Error("missing entry")
+	}
+
+	if !conns.Connections["ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"].Connected {
+		t.Error("missing entry value")
+	}
+}


### PR DESCRIPTION
Fixes #50  

## Proposed changes
- Catch errors in the portforward, and restart the connectivity
-  Monitor the state of the connection with syncthing, and restart when it's marked as disconnected
