### PR TITLE
Support for env vars

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cloudnativedevelopment/cnd/pkg/analytics"
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
+	"github.com/cloudnativedevelopment/cnd/pkg/log"
 	"github.com/cloudnativedevelopment/cnd/pkg/model"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/k8/deployments"
@@ -55,6 +56,7 @@ func Up() *cobra.Command {
 
 			stopChannel := make(chan os.Signal, 1)
 			signal.Notify(stopChannel, os.Interrupt)
+			log.Debugf("%s ready, waiting for stop signal to shut down", fullname)
 			<-stopChannel
 			fmt.Println()
 			return nil

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cloudnativedevelopment/cnd/pkg/k8/secrets"
 	"github.com/cloudnativedevelopment/cnd/pkg/log"
 	"github.com/cloudnativedevelopment/cnd/pkg/model"
+
+	// github.com/logrusorgru/aurora requires the usage of dot imports
 	. "github.com/logrusorgru/aurora"
 
 	"k8s.io/apimachinery/pkg/fields"

--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -101,7 +101,7 @@ func updateCndContainer(c *apiv1.Container, dev *model.Dev, namespace string) {
 	c.Env = mergeEnvironmentVariables(c.Env, dev.Environment, namespace)
 }
 
-func mergeEnvironmentVariables(current []v1.EnvVar, dev map[string]string, namespace string) []v1.EnvVar {
+func mergeEnvironmentVariables(current []v1.EnvVar, dev []model.EnvVar, namespace string) []v1.EnvVar {
 	mergedEnv := map[string]string{}
 
 	for _, k := range current {
@@ -110,8 +110,8 @@ func mergeEnvironmentVariables(current []v1.EnvVar, dev map[string]string, names
 
 	mergedEnv[cndEnvNamespace] = namespace
 
-	for k, v := range dev {
-		mergedEnv[k] = v
+	for _, val := range dev {
+		mergedEnv[val.Name] = val.Value
 	}
 
 	finalMerge := make([]v1.EnvVar, len(mergedEnv))

--- a/pkg/k8/deployments/translate_test.go
+++ b/pkg/k8/deployments/translate_test.go
@@ -58,7 +58,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 	tests := []struct {
 		name       string
 		deployment []v1.EnvVar
-		dev        map[string]string
+		dev        []model.EnvVar
 		expected   []v1.EnvVar
 	}{
 		{
@@ -66,7 +66,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 			nil,
 			nil,
 			[]v1.EnvVar{
-				v1.EnvVar{
+				{
 					Name:  "CND_KUBERNETES_NAMESPACE",
 					Value: "cnd-namespace",
 				},
@@ -75,9 +75,9 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 		{
 			"both-empty",
 			[]v1.EnvVar{},
-			map[string]string{},
+			[]model.EnvVar{},
 			[]v1.EnvVar{
-				v1.EnvVar{
+				{
 					Name:  "CND_KUBERNETES_NAMESPACE",
 					Value: "cnd-namespace",
 				},
@@ -86,37 +86,42 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 		{
 			"no-overlap",
 			[]v1.EnvVar{
-				v1.EnvVar{
+				{
 					Name:  "deployment",
 					Value: "value-from-deployment",
 				},
-				v1.EnvVar{
+				{
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
 				},
 			},
-			map[string]string{
-				"dev":  "on",
-				"test": "true",
+			[]model.EnvVar{
+				{
+					Name:  "dev",
+					Value: "on"},
+				{
+					Name:  "test",
+					Value: "true",
+				},
 			},
 			[]v1.EnvVar{
-				v1.EnvVar{
+				{
 					Name:  "CND_KUBERNETES_NAMESPACE",
 					Value: "cnd-namespace",
 				},
-				v1.EnvVar{
+				{
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
 				},
-				v1.EnvVar{
+				{
 					Name:  "deployment",
 					Value: "value-from-deployment",
 				},
-				v1.EnvVar{
+				{
 					Name:  "dev",
 					Value: "on",
 				},
-				v1.EnvVar{
+				{
 					Name:  "test",
 					Value: "true",
 				},
@@ -125,38 +130,47 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 		{
 			"overlap",
 			[]v1.EnvVar{
-				v1.EnvVar{
+				{
 					Name:  "deployment",
 					Value: "value-from-deployment",
 				},
-				v1.EnvVar{
+				{
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
 				},
 			},
-			map[string]string{
-				"dev":                "on",
-				"test":               "true",
-				"another-deployment": "overriden-value-from-dev",
-			},
-			[]v1.EnvVar{
-				v1.EnvVar{
-					Name:  "CND_KUBERNETES_NAMESPACE",
-					Value: "cnd-namespace",
-				},
-				v1.EnvVar{
-					Name:  "another-deployment",
-					Value: "overriden-value-from-dev",
-				},
-				v1.EnvVar{
-					Name:  "deployment",
-					Value: "value-from-deployment",
-				},
-				v1.EnvVar{
+			[]model.EnvVar{
+				{
 					Name:  "dev",
 					Value: "on",
 				},
-				v1.EnvVar{
+				{
+					Name:  "test",
+					Value: "true",
+				},
+				{
+					Name:  "another-deployment",
+					Value: "overriden-value-from-dev",
+				},
+			},
+			[]v1.EnvVar{
+				{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
+				{
+					Name:  "another-deployment",
+					Value: "overriden-value-from-dev",
+				},
+				{
+					Name:  "deployment",
+					Value: "value-from-deployment",
+				},
+				{
+					Name:  "dev",
+					Value: "on",
+				},
+				{
 					Name:  "test",
 					Value: "true",
 				},

--- a/pkg/k8/deployments/translate_test.go
+++ b/pkg/k8/deployments/translate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cloudnativedevelopment/cnd/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func Test_updateCNDContainer(t *testing.T) {
@@ -51,4 +52,131 @@ func Test_updateCNDContainer(t *testing.T) {
 		t.Errorf("CND dev context wasn't set: %+v", c)
 	}
 
+}
+
+func Test_mergeEnvironmentVariables(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment []v1.EnvVar
+		dev        map[string]string
+		expected   []v1.EnvVar
+	}{
+		{
+			"both-nil",
+			nil,
+			nil,
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
+			},
+		},
+		{
+			"both-empty",
+			[]v1.EnvVar{},
+			map[string]string{},
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
+			},
+		},
+		{
+			"no-overlap",
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "deployment",
+					Value: "value-from-deployment",
+				},
+				v1.EnvVar{
+					Name:  "another-deployment",
+					Value: "another-value-from-deployment",
+				},
+			},
+			map[string]string{
+				"dev":  "on",
+				"test": "true",
+			},
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
+				v1.EnvVar{
+					Name:  "another-deployment",
+					Value: "another-value-from-deployment",
+				},
+				v1.EnvVar{
+					Name:  "deployment",
+					Value: "value-from-deployment",
+				},
+				v1.EnvVar{
+					Name:  "dev",
+					Value: "on",
+				},
+				v1.EnvVar{
+					Name:  "test",
+					Value: "true",
+				},
+			},
+		},
+		{
+			"overlap",
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "deployment",
+					Value: "value-from-deployment",
+				},
+				v1.EnvVar{
+					Name:  "another-deployment",
+					Value: "another-value-from-deployment",
+				},
+			},
+			map[string]string{
+				"dev":                "on",
+				"test":               "true",
+				"another-deployment": "overriden-value-from-dev",
+			},
+			[]v1.EnvVar{
+				v1.EnvVar{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
+				v1.EnvVar{
+					Name:  "another-deployment",
+					Value: "overriden-value-from-dev",
+				},
+				v1.EnvVar{
+					Name:  "deployment",
+					Value: "value-from-deployment",
+				},
+				v1.EnvVar{
+					Name:  "dev",
+					Value: "on",
+				},
+				v1.EnvVar{
+					Name:  "test",
+					Value: "true",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeEnvironmentVariables(tt.deployment, tt.dev, "cnd-namespace")
+			for i := range result {
+				if result[i].Name != tt.expected[i].Name {
+					t.Fatalf("failed to merge name. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", result[i].Name, tt.expected[i].Name, result, tt.expected)
+				}
+
+				if result[i].Value != tt.expected[i].Value {
+					t.Fatalf("failed to merge value. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", result[i].Value, tt.expected[i].Value, result, tt.expected)
+				}
+			}
+
+		})
+	}
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -36,9 +36,10 @@ const (
 
 //Dev represents a cloud native development environment
 type Dev struct {
-	Swap    Swap              `json:"swap" yaml:"swap"`
-	Mount   Mount             `json:"mount" yaml:"mount"`
-	Scripts map[string]string `json:"scripts" yaml:"scripts"`
+	Swap        Swap              `json:"swap" yaml:"swap"`
+	Mount       Mount             `json:"mount" yaml:"mount"`
+	Scripts     map[string]string `json:"scripts" yaml:"scripts"`
+	Environment map[string]string `json:"environment,omitempty" yaml:"environment,omitempty"`
 }
 
 //Swap represents the metadata for the container to be swapped
@@ -71,7 +72,8 @@ func NewDev() *Dev {
 			Source: ".",
 			Target: "/app",
 		},
-		Scripts: make(map[string]string),
+		Scripts:     make(map[string]string),
+		Environment: make(map[string]string),
 	}
 }
 
@@ -113,14 +115,9 @@ func ReadDev(devPath string) (*Dev, error) {
 
 // LoadDev loads the dev object from the array, plus defaults.
 func LoadDev(b []byte) (*Dev, error) {
-	dev := Dev{
-		Mount: Mount{
-			Source: ".",
-			Target: "/src",
-		},
-	}
+	dev := NewDev()
 
-	err := yaml.Unmarshal(b, &dev)
+	err := yaml.Unmarshal(b, dev)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +127,7 @@ func LoadDev(b []byte) (*Dev, error) {
 		dev.Mount.Source = filepath.Join(home, dev.Mount.Source[2:])
 	}
 
-	return &dev, nil
+	return dev, nil
 }
 
 func (dev *Dev) fixPath(originalPath string) {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -39,7 +39,7 @@ type Dev struct {
 	Swap        Swap              `json:"swap" yaml:"swap"`
 	Mount       Mount             `json:"mount" yaml:"mount"`
 	Scripts     map[string]string `json:"scripts" yaml:"scripts"`
-	Environment map[string]string `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Environment []EnvVar          `json:"environment,omitempty" yaml:"environment,omitempty"`
 }
 
 //Swap represents the metadata for the container to be swapped
@@ -62,6 +62,45 @@ type Mount struct {
 	Target string `json:"target" yaml:"target"`
 }
 
+// EnvVar represents an environment value. When loaded, it will expand from the current env
+type EnvVar struct {
+	Name  string
+	Value string
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (e *EnvVar) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw string
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(raw, "=", 2)
+	e.Name = parts[0]
+	if len(parts) == 2 {
+		if strings.HasPrefix(parts[1], "$") {
+			e.Value = os.ExpandEnv(parts[1])
+			return nil
+		}
+
+		e.Value = parts[1]
+		return nil
+	}
+
+	val := os.ExpandEnv(parts[0])
+	if val != parts[0] {
+		e.Value = val
+	}
+
+	return nil
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (e *EnvVar) MarshalYAML() (interface{}, error) {
+	return e.Name + "=" + e.Value, nil
+}
+
 //NewDev returns a new instance of dev with default values
 func NewDev() *Dev {
 	return &Dev{
@@ -73,7 +112,7 @@ func NewDev() *Dev {
 			Target: "/app",
 		},
 		Scripts:     make(map[string]string),
-		Environment: make(map[string]string),
+		Environment: make([]EnvVar, 0),
 	}
 }
 


### PR DESCRIPTION
Fixes #164

## Proposed changes
- Add an 'environment' value to the manifest, for the developer to specify env vars. This will be added to the dev mode. If the variable already exists in the deployment, the one from cnd.yml will take precedence.
- The user can also expand variables by following the format ${VAR} and $VAR
- If the variable doesn't have a value (e.g. `- FOO`) we'll try to expand it, like docker-compose does.
 
cnd.yml:

```yaml
swap:
  deployment:
    name: blog
    image: okteto/rails-blog:0.1.3
    command:
    - tail
    - -f
    - /dev/null
mount:
  source: .
  target: /usr/src/app
environment:
  - GMAIL_USERNAME=ramiro@okteto.com
  - IS_PROD=true
  - NAME=$USER
  - USER
  - ENV=development
scripts:
  hello: echo Your cluster ♥s you
  migrate: rails db:migrate
  server: rails s
```

resulting deployment:
```yaml
...
spec:
      containers:
      - command:
        - tail
        - -f
        - /dev/null
        env:
        - name: CND_KUBERNETES_NAMESPACE
          value: ramiro
        - name: ENV
          value: development
        - name: GMAIL_USERNAME
          value: ramiro@okteto.com
        - name: IS_PROD
          value: "true"
        - name: NAME
          value: ramiro
...
```