### PR TITLE
exit cnd up if syncthing is in a bad state

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -65,7 +65,7 @@ func Up() *cobra.Command {
 					fmt.Println()
 					return nil
 				case <-disconnectChannel:
-					return fmt.Errorf("syncthing is not available, disconnecting")
+					return fmt.Errorf("Cluster connection lost. Run '%s up' to connect again", config.GetBinaryName())
 				}
 			}
 		},

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -43,7 +43,9 @@ func Up() *cobra.Command {
 			var wg sync.WaitGroup
 			defer shutdown(cancel, &wg)
 
-			d, err := ExecuteUp(ctx, &wg, dev, namespace)
+			disconnectChannel := make(chan struct{}, 1)
+
+			d, err := ExecuteUp(ctx, &wg, dev, namespace, disconnectChannel)
 			if err != nil {
 				return err
 			}
@@ -57,9 +59,15 @@ func Up() *cobra.Command {
 			stopChannel := make(chan os.Signal, 1)
 			signal.Notify(stopChannel, os.Interrupt)
 			log.Debugf("%s ready, waiting for stop signal to shut down", fullname)
-			<-stopChannel
-			fmt.Println()
-			return nil
+			for {
+				select {
+				case <-stopChannel:
+					fmt.Println()
+					return nil
+				case <-disconnectChannel:
+					return fmt.Errorf("syncthing is not available, disconnecting")
+				}
+			}
 		},
 	}
 
@@ -69,7 +77,7 @@ func Up() *cobra.Command {
 }
 
 // ExecuteUp runs all the logic for the up command
-func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespace string) (*appsv1.Deployment, error) {
+func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespace string, monitor chan struct{}) (*appsv1.Deployment, error) {
 
 	n, deploymentName, c, err := findDevEnvironment(true)
 
@@ -141,6 +149,7 @@ func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespac
 	wg.Add(1)
 	go logs.StreamLogs(ctx, wg, d, dev.Swap.Deployment.Container, client)
 
+	go sy.Monitor(ctx, monitor)
 	return d, nil
 }
 

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -162,7 +162,7 @@ func GetPodEvents(ctx context.Context, pod *apiv1.Pod, c *kubernetes.Clientset) 
 			}
 
 			if event.Type == "Normal" {
-				log.Debug(event.Message)
+				log.Debugf("Kubernetes: %s", event.Message)
 			} else {
 				fmt.Println(Red("Kubernetes: "), event.Message)
 			}

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -1,14 +1,11 @@
 package syncthing
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
 	"time"
-
-	"github.com/cloudnativedevelopment/cnd/pkg/log"
 )
 
 type addAPIKeyTransport struct {
@@ -34,26 +31,6 @@ func NewAPIClient() *http.Client {
 		Timeout:   15 * time.Second,
 		Transport: &addAPIKeyTransport{http.DefaultTransport},
 	}
-}
-
-func (s *Syncthing) isConnectedToRemote() bool {
-	body, err := s.GetFromAPI("rest/system/connections")
-	if err != nil {
-		log.Debugf("error when getting connections from the api: %s", err)
-		return true
-	}
-
-	var conns syncthingConnections
-	if err := json.Unmarshal(body, &conns); err != nil {
-		return true
-	}
-
-	if val, ok := conns.Connections[s.RemoteDeviceID]; ok {
-		return val.Connected
-	}
-
-	log.Infof("RemoteDeviceID %s missing from the response", s.RemoteDeviceID)
-	return true
 }
 
 // GetFromAPI calls the syncthing API and returns the parsed json or an error

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -1,0 +1,87 @@
+package syncthing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/cloudnativedevelopment/cnd/pkg/log"
+)
+
+type addAPIKeyTransport struct {
+	T http.RoundTripper
+}
+
+// API types
+
+type syncthingConnections struct {
+	Connections map[string]struct {
+		Connected bool `json:"connected,omitempty"`
+	} `json:"connections,omitempty"`
+}
+
+func (akt *addAPIKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("X-API-Key", "cnd")
+	return akt.T.RoundTrip(req)
+}
+
+//NewAPIClient returns a new syncthing api client configured to call the syncthing api
+func NewAPIClient() *http.Client {
+	return &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: &addAPIKeyTransport{http.DefaultTransport},
+	}
+}
+
+func (s *Syncthing) isConnectedToRemote() bool {
+	body, err := s.GetFromAPI("rest/system/connections")
+	if err != nil {
+		log.Debugf("error when getting connections from the api: %s", err)
+		return true
+	}
+
+	var conns syncthingConnections
+	if err := json.Unmarshal(body, &conns); err != nil {
+		return true
+	}
+
+	if val, ok := conns.Connections[s.RemoteDeviceID]; ok {
+		return val.Connected
+	}
+
+	log.Infof("RemoteDeviceID %s missing from the response", s.RemoteDeviceID)
+	return true
+}
+
+// GetFromAPI calls the syncthing API and returns the parsed json or an error
+func (s *Syncthing) GetFromAPI(url string) ([]byte, error) {
+	urlPath := path.Join(s.GUIAddress, url)
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s", urlPath), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("limit", "30")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("bad response from syncthing api %s %d: %s", req.URL.String(), resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/pkg/syncthing/api_test.go
+++ b/pkg/syncthing/api_test.go
@@ -1,0 +1,60 @@
+package syncthing
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshallResponse(t *testing.T) {
+	body := []byte(`{
+		"connections": {
+		  "ABKAVQF-RUO4CYO-FSC2VIP-VRX4QDA-TQQRN2J-MRDXJUC-FXNWP6N-S6ZSAAR": {
+			"address": "",
+			"at": "0001-01-01T00:00:00Z",
+			"clientVersion": "",
+			"connected": false,
+			"inBytesTotal": 0,
+			"outBytesTotal": 0,
+			"paused": false,
+			"type": ""
+		  },
+		  "ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU": {
+			"address": "[::1]:51761",
+			"at": "2019-01-27T02:45:20.406724-08:00",
+			"clientVersion": "v1.0.0",
+			"connected": true,
+			"inBytesTotal": 161,
+			"outBytesTotal": 181,
+			"paused": false,
+			"type": "tcp-client"
+		  }
+		},
+		"total": {
+		  "address": "",
+		  "at": "2019-01-27T02:45:20.406734-08:00",
+		  "clientVersion": "",
+		  "connected": false,
+		  "inBytesTotal": 161,
+		  "outBytesTotal": 181,
+		  "paused": false,
+		  "type": ""
+		}
+	  }`)
+
+	var conns syncthingConnections
+	if err := json.Unmarshal(body, &conns); err != nil {
+		t.Fatalf("%s\n%s", body, err)
+	}
+
+	if len(conns.Connections) == 0 {
+		t.Fatalf("didn't parse the connections")
+	}
+
+	if _, ok := conns.Connections["ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"]; !ok {
+		t.Error("missing entry")
+	}
+
+	if !conns.Connections["ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"].Connected {
+		t.Error("missing entry value")
+	}
+}

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -1,0 +1,33 @@
+package syncthing
+
+import (
+	"context"
+	"time"
+)
+
+var consecutiveErrors = 0
+
+const maxConsecutiveErrors = 3
+
+//Monitor verifies that syncthing is not in a disconnected state. If so, it sends a message to the
+// disconnected channel and exits
+func (s *Syncthing) Monitor(ctx context.Context, disconnected chan struct{}) {
+	ticker := time.NewTicker(5 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			if !s.isConnectedToRemote() {
+				consecutiveErrors++
+				if consecutiveErrors > maxConsecutiveErrors {
+					disconnected <- struct{}{}
+					return
+				}
+			} else {
+				consecutiveErrors = 0
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -56,6 +57,7 @@ type Syncthing struct {
 	FileWatcherDelay int
 	GUIAddress       string
 	ListenAddress    string
+	Client           *http.Client
 }
 
 // NewSyncthing constructs a new Syncthing.
@@ -100,6 +102,7 @@ func NewSyncthing(namespace, deployment string, devList []*model.Dev) (*Syncthin
 		FileWatcherDelay: DefaultFileWatcherDelay,
 		GUIAddress:       fmt.Sprintf("127.0.0.1:%d", guiPort),
 		ListenAddress:    fmt.Sprintf("0.0.0.0:%d", listenPort),
+		Client:           NewAPIClient(),
 	}
 
 	return s, nil


### PR DESCRIPTION
## Proposed changes
- Stop `cnd up` with an error if we can't talk to syncthing. This would typically happen if syncthing is dead, or if there's not connectivity (e.g. the forwarding tunnel is down).

I'm just stopping instead of retrying as the first step in making cnd more stable to bad network situations. Once I understand the issues and can reproduce it better I'll switch it to a retry model.
