### PR TITLE
Reconnect port forward when we detect a disconnection

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -19,6 +19,7 @@ func Down() *cobra.Command {
 		Use:   "down",
 		Short: "Deactivate your cloud native development environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug("starting down command")
 			return executeDown()
 		},
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/analytics"
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
@@ -29,6 +30,7 @@ func Up() *cobra.Command {
 		Use:   "up",
 		Short: "Activate your cloud native development environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Debugf("starting up command")
 			dev, err := model.ReadDev(devPath)
 			if err != nil {
 				return err
@@ -45,7 +47,7 @@ func Up() *cobra.Command {
 
 			disconnectChannel := make(chan struct{}, 1)
 
-			d, err := ExecuteUp(ctx, &wg, dev, namespace, disconnectChannel)
+			d, pf, err := ExecuteUp(ctx, &wg, dev, namespace, disconnectChannel)
 			if err != nil {
 				return err
 			}
@@ -58,14 +60,22 @@ func Up() *cobra.Command {
 
 			stopChannel := make(chan os.Signal, 1)
 			signal.Notify(stopChannel, os.Interrupt)
+
+			debugChannel := make(chan os.Signal, 1)
+			signal.Notify(debugChannel, syscall.SIGUSR2)
+
 			log.Debugf("%s ready, waiting for stop signal to shut down", fullname)
 			for {
 				select {
 				case <-stopChannel:
 					fmt.Println()
 					return nil
+				case <-debugChannel:
+					log.Debugf("SIGUSR2 received, reconnecting port forward")
+					disconnectChannel <- struct{}{}
 				case <-disconnectChannel:
-					return fmt.Errorf("Cluster connection lost. Run '%s up' to connect again", config.GetBinaryName())
+					log.Debug("Cluster connection lost, reconnecting...")
+					reconnectPortForward(ctx, &wg, d, pf)
 				}
 			}
 		},
@@ -77,81 +87,106 @@ func Up() *cobra.Command {
 }
 
 // ExecuteUp runs all the logic for the up command
-func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespace string, monitor chan struct{}) (*appsv1.Deployment, error) {
+func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespace string, monitor chan struct{}) (*appsv1.Deployment, *forward.CNDPortForward, error) {
 
 	n, deploymentName, c, err := findDevEnvironment(true)
 
 	if err != errNoCNDEnvironment {
-		return nil, fmt.Errorf("there is already an entry for %s/%s Are you running '%s up' somewhere else?", config.GetBinaryName(), deployments.GetFullName(n, deploymentName), c)
+		return nil, nil, fmt.Errorf("there is already an entry for %s/%s Are you running '%s up' somewhere else?", config.GetBinaryName(), deployments.GetFullName(n, deploymentName), c)
 	}
 
 	namespace, client, restConfig, err := GetKubernetesClient(namespace)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	d, err := deployments.Get(namespace, dev.Swap.Deployment.Name, client)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
 	dev.Swap.Deployment.Container = deployments.GetDevContainerOrFirst(
 		dev.Swap.Deployment.Container,
 		d.Spec.Template.Spec.Containers,
 	)
+
 	devList, err := deployments.GetAndUpdateDevListFromAnnotation(d.GetObjectMeta(), dev)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sy, err := syncthing.NewSyncthing(namespace, d.Name, devList)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := deployments.DevModeOn(d, devList, client); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	pod, err := deployments.GetCNDPod(ctx, d, client)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	go deployments.GetPodEvents(ctx, pod, client)
 
 	if err := deployments.InitVolumeWithTarball(ctx, client, restConfig, namespace, pod.Name, devList); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	fullname := deployments.GetFullName(namespace, d.Name)
 
 	pf, err := forward.NewCNDPortForward(sy.RemoteAddress)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := sy.Run(ctx, wg); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = storage.Insert(ctx, wg, namespace, dev, sy.GUIAddress)
 	if err != nil {
 		if err == storage.ErrAlreadyRunning {
 			log.Infof("failed to insert new state value for %s", fullname)
-			return nil, fmt.Errorf("there is already an entry for %s. Are you running '%s up' somewhere else?", config.GetBinaryName(), fullname)
+			return nil, nil, fmt.Errorf("there is already an entry for %s. Are you running '%s up' somewhere else?", config.GetBinaryName(), fullname)
 		}
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := pf.Start(ctx, wg, client, restConfig, pod); err != nil {
-		return nil, fmt.Errorf("couldn't start the connection to your cluster: %s", err)
+		return nil, nil, fmt.Errorf("couldn't start the connection to your cluster: %s", err)
 	}
 
 	wg.Add(1)
 	go logs.StreamLogs(ctx, wg, d, dev.Swap.Deployment.Container, client)
 
 	go sy.Monitor(ctx, monitor)
-	return d, nil
+	return d, pf, nil
+}
+
+func reconnectPortForward(ctx context.Context, wg *sync.WaitGroup, d *appsv1.Deployment, pf *forward.CNDPortForward) error {
+
+	pf.Stop()
+
+	_, client, restConfig, err := GetKubernetesClient(d.Namespace)
+	if err != nil {
+		return err
+	}
+
+	pod, err := deployments.GetCNDPod(ctx, d, client)
+	if err != nil {
+		return err
+	}
+
+	if err := pf.Start(ctx, wg, client, restConfig, pod); err != nil {
+		return fmt.Errorf("couldn't start the connection to your cluster: %s", err)
+	}
+
+	log.Infof("reconnected port-forwarder-%d:%d", pf.LocalPort, pf.RemotePort)
+
+	return nil
 }
 
 func shutdown(cancel context.CancelFunc, wg *sync.WaitGroup) {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -190,6 +190,11 @@ func reconnectPortForward(ctx context.Context, wg *sync.WaitGroup, d *appsv1.Dep
 }
 
 func shutdown(cancel context.CancelFunc, wg *sync.WaitGroup) {
+	log.Debugf("cancelling context")
 	cancel()
+
+	log.Debugf("waiting for tasks for be done")
 	wg.Wait()
+
+	log.Debugf("completed shutdown sequence")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -41,7 +41,6 @@ func Up() *cobra.Command {
 			fmt.Println("Activating your cloud native development environment...")
 
 			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			var wg sync.WaitGroup
 			defer shutdown(cancel, &wg)
 
@@ -68,6 +67,7 @@ func Up() *cobra.Command {
 			for {
 				select {
 				case <-stopChannel:
+					log.Debugf("CTRL+C received, starting shutdown sequence")
 					fmt.Println()
 					return nil
 				case <-debugChannel:

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -137,11 +137,6 @@ func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespac
 
 	fullname := deployments.GetFullName(namespace, d.Name)
 
-	pf, err := forward.NewCNDPortForward(sy.RemoteAddress)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if err := sy.Run(ctx, wg); err != nil {
 		return nil, nil, err
 	}
@@ -152,6 +147,11 @@ func ExecuteUp(ctx context.Context, wg *sync.WaitGroup, dev *model.Dev, namespac
 			log.Infof("failed to insert new state value for %s", fullname)
 			return nil, nil, fmt.Errorf("there is already an entry for %s. Are you running '%s up' somewhere else?", config.GetBinaryName(), fullname)
 		}
+		return nil, nil, err
+	}
+
+	pf, err := forward.NewCNDPortForward(sy.RemoteAddress)
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/analytics"
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
@@ -60,9 +59,6 @@ func Up() *cobra.Command {
 			stopChannel := make(chan os.Signal, 1)
 			signal.Notify(stopChannel, os.Interrupt)
 
-			debugChannel := make(chan os.Signal, 1)
-			signal.Notify(debugChannel, syscall.SIGUSR2)
-
 			log.Debugf("%s ready, waiting for stop signal to shut down", fullname)
 			for {
 				select {
@@ -70,9 +66,6 @@ func Up() *cobra.Command {
 					log.Debugf("CTRL+C received, starting shutdown sequence")
 					fmt.Println()
 					return nil
-				case <-debugChannel:
-					log.Debugf("SIGUSR2 received, reconnecting port forward")
-					disconnectChannel <- struct{}{}
 				case <-disconnectChannel:
 					log.Debug("Cluster connection lost, reconnecting...")
 					reconnectPortForward(ctx, &wg, d, pf)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,6 @@ import (
 )
 
 func main() {
-	log.Init(logrus.WarnLevel)
+	log.Init(logrus.WarnLevel, cmd.GetActionID())
 	os.Exit(cmd.Execute())
 }

--- a/pkg/k8/exec/exec.go
+++ b/pkg/k8/exec/exec.go
@@ -57,7 +57,6 @@ func Exec(ctx context.Context, c *kubernetes.Clientset, config *rest.Config, pod
 			TTY:       t.Raw,
 		}, scheme.ParameterCodec)
 
-		req.Context(ctx)
 		return p.Executor.Execute("POST", req.URL(), config, p.In, p.Out, p.ErrOut, t.Raw, sizeQueue)
 	}
 

--- a/pkg/k8/forward/forward.go
+++ b/pkg/k8/forward/forward.go
@@ -87,7 +87,7 @@ func (p *CNDPortForward) Start(
 
 	go func() {
 		<-ctx.Done()
-		log.Debugf("initiating portforward cancellation sequence")
+		log.Debugf("starting portforward cancellation sequence")
 		p.Stop()
 		return
 	}()
@@ -115,5 +115,5 @@ func (p *CNDPortForward) Stop() {
 		close(p.StopChan)
 		<-p.StopChan
 	}
-	log.Debug("port forward clean shutdown")
+	log.Debug("port forward stopped gracefully")
 }

--- a/pkg/k8/forward/forward.go
+++ b/pkg/k8/forward/forward.go
@@ -20,13 +20,14 @@ import (
 //CNDPortForward holds the information of the port forward
 type CNDPortForward struct {
 	StopChan       chan struct{}
-	ReadyChan      chan struct{}
 	IsReady        bool
 	LocalPort      int
 	RemotePort     int
 	LocalPath      string
 	DeploymentName string
 	Out            *bytes.Buffer
+	wg             *sync.WaitGroup
+	mux            sync.Mutex
 }
 
 //NewCNDPortForward initializes and returns a new port forward structure
@@ -41,10 +42,8 @@ func NewCNDPortForward(remoteAddress string) (*CNDPortForward, error) {
 	return &CNDPortForward{
 		LocalPort:  port,
 		RemotePort: 22000,
-		StopChan:   make(chan struct{}, 1),
-		ReadyChan:  make(chan struct{}, 1),
-		Out:        new(bytes.Buffer),
 		IsReady:    false,
+		Out:        new(bytes.Buffer),
 	}, nil
 }
 
@@ -52,6 +51,9 @@ func NewCNDPortForward(remoteAddress string) (*CNDPortForward, error) {
 func (p *CNDPortForward) Start(
 	ctx context.Context, wg *sync.WaitGroup,
 	c *kubernetes.Clientset, config *rest.Config, pod *apiv1.Pod) error {
+
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
 	req := c.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -65,12 +67,14 @@ func (p *CNDPortForward) Start(
 	}
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
-
+	p.StopChan = make(chan struct{}, 1)
+	p.Out = new(bytes.Buffer)
+	ready := make(chan struct{}, 1)
 	pf, err := portforward.New(
 		dialer,
 		[]string{fmt.Sprintf("%d:%d", p.LocalPort, p.RemotePort)},
 		p.StopChan,
-		p.ReadyChan,
+		ready,
 		p.Out,
 		p.Out)
 
@@ -78,20 +82,38 @@ func (p *CNDPortForward) Start(
 		return err
 	}
 
-	wg.Add(1)
+	p.wg = wg
+	p.wg.Add(1)
+
 	go func() {
-		defer wg.Done()
 		<-ctx.Done()
-		if p.StopChan != nil {
-			close(p.StopChan)
-			<-p.StopChan
-		}
-		log.Debug("port forward clean shutdown")
+		log.Debugf("initiating portforward cancellation sequence")
+		p.Stop()
+		return
 	}()
 
-	go pf.ForwardPorts()
+	p.IsReady = false
+	go func(f *portforward.PortForwarder) {
+		f.ForwardPorts()
+		log.Debugf("forwardPorts goroutine finished")
+		return
+	}(pf)
 
 	<-pf.Ready
 	p.IsReady = true
 	return nil
+}
+
+// Stop cleanly shutdowns the port forwarder
+func (p *CNDPortForward) Stop() {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	defer p.wg.Done()
+	log.Debugf("[port-forward-%d:%d]: %s", p.LocalPort, p.RemotePort, p.Out.String())
+	if p.StopChan != nil {
+		close(p.StopChan)
+		<-p.StopChan
+	}
+	log.Debug("port forward clean shutdown")
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -14,7 +14,7 @@ import (
 
 type logger struct {
 	out  *logrus.Logger
-	file *logrus.Logger
+	file *logrus.Entry
 }
 
 var log = &logger{
@@ -22,21 +22,21 @@ var log = &logger{
 }
 
 // Init configures the logger for the package to use.
-func Init(level logrus.Level) {
+func Init(level logrus.Level, actionID string) {
 	log.out.SetOutput(os.Stdout)
 	log.out.SetLevel(level)
 
-	log.file = logrus.New()
-	log.file.SetFormatter(&logrus.TextFormatter{
+	fileLogger := logrus.New()
+	fileLogger.SetFormatter(&logrus.TextFormatter{
 		DisableColors: true,
 		FullTimestamp: true,
 	})
 
 	logPath := path.Join(config.GetCNDHome(), fmt.Sprintf("%s%s", config.GetBinaryName(), ".log"))
 	rolling := getRollingLog(logPath)
-	log.file.SetOutput(rolling)
-	log.file.SetLevel(logrus.DebugLevel)
-
+	fileLogger.SetOutput(rolling)
+	fileLogger.SetLevel(logrus.DebugLevel)
+	log.file = fileLogger.WithFields(logrus.Fields{"action": actionID})
 }
 
 func getRollingLog(path string) io.Writer {

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -45,7 +45,10 @@ func (s *Syncthing) Monitor(ctx context.Context, disconnected chan struct{}) {
 				consecutiveErrors++
 				if consecutiveErrors > maxConsecutiveErrors {
 					log.Infof("not connected to syncthing, sending disconnect notification")
-					disconnected <- struct{}{}
+					if disconnected != nil {
+						disconnected <- struct{}{}
+					}
+
 					return
 				}
 			} else {


### PR DESCRIPTION
Fixes #50

## Proposed changes
- Stop and start the portforward between the local machine and the remote sync process when the syncthing API detects the remote as 'disconnected'
- Add a monitoring loop to see the state of syncthing, and log when there's a connectivity issue

