### PR TITLE
don't query syncthing for inactive environments

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -76,6 +76,10 @@ func list(yamlOutput bool) error {
 			Client:     client,
 		}
 
+		if sy.GUIAddress == "" {
+			continue
+		}
+
 		completion, err := getStatus(sy, svc)
 		if err == nil {
 			env.Completion = fmt.Sprintf("%2.f%%", completion)
@@ -109,7 +113,7 @@ func getStatus(sy *syncthing.Syncthing, s storage.Service) (float64, error) {
 
 	var events []event
 	if err := json.Unmarshal(body, &events); err != nil {
-		return 0, fmt.Errorf("error getting syncthing state: %s", err)
+		return 0, fmt.Errorf("error unmarshalling syncthing state: %s", err)
 	}
 
 	for i := len(events) - 1; i >= 0; i-- {


### PR DESCRIPTION

## Proposed changes
- If the service doesn't have a syncthing address in the state, it means that it's not currently running. If that's the  case, don't check for syncthing status (since it will just time out)
