### PR TITLE
Keep `valueFrom` for deployment envvars

### DIFF
--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"sort"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/log"
 	"github.com/cloudnativedevelopment/cnd/pkg/model"
@@ -101,39 +100,29 @@ func updateCndContainer(c *apiv1.Container, dev *model.Dev, namespace string) {
 	)
 
 	c.Resources = apiv1.ResourceRequirements{}
-	c.Env = mergeEnvironmentVariables(c.Env, dev.Environment, namespace)
+	mergeEnvironmentVariables(c, dev.Environment, namespace)
 }
 
-func mergeEnvironmentVariables(current []v1.EnvVar, dev []model.EnvVar, namespace string) []v1.EnvVar {
-	mergedEnv := map[string]string{}
+func mergeEnvironmentVariables(c *v1.Container, devEnv []model.EnvVar, namespace string) {
+	devEnv = append(devEnv, model.EnvVar{Name: cndEnvNamespace, Value: namespace})
+	unusedDevEnv := map[string]string{}
 
-	for _, k := range current {
-		mergedEnv[k.Name] = k.Value
+	for _, val := range devEnv {
+		unusedDevEnv[val.Name] = val.Value
 	}
 
-	mergedEnv[cndEnvNamespace] = namespace
-
-	for _, val := range dev {
-		mergedEnv[val.Name] = val.Value
-	}
-
-	finalMerge := make([]v1.EnvVar, len(mergedEnv))
-	counter := 0
-	for k, v := range mergedEnv {
-		finalMerge[counter] = v1.EnvVar{
-			Name:  k,
-			Value: v,
+	for i, envvar := range c.Env {
+		if value, ok := unusedDevEnv[envvar.Name]; ok {
+			c.Env[i] = v1.EnvVar{Name: envvar.Name, Value: value}
+			delete(unusedDevEnv, envvar.Name)
 		}
-
-		counter++
 	}
 
-	sort.Slice(finalMerge, func(i, j int) bool {
-		return finalMerge[i].Name < finalMerge[j].Name
-	})
-
-	return finalMerge
-
+	for _, envvar := range devEnv {
+		if value, ok := unusedDevEnv[envvar.Name]; ok {
+			c.Env = append(c.Env, v1.EnvVar{Name: envvar.Name, Value: value})
+		}
+	}
 }
 
 func createInitSyncthingContainer(d *appsv1.Deployment, dev *model.Dev) {

--- a/pkg/k8/deployments/translate_test.go
+++ b/pkg/k8/deployments/translate_test.go
@@ -56,14 +56,14 @@ func Test_updateCNDContainer(t *testing.T) {
 
 func Test_mergeEnvironmentVariables(t *testing.T) {
 	tests := []struct {
-		name       string
-		deployment []v1.EnvVar
-		dev        []model.EnvVar
-		expected   []v1.EnvVar
+		name      string
+		container *v1.Container
+		dev       []model.EnvVar
+		expected  []v1.EnvVar
 	}{
 		{
 			"both-nil",
-			nil,
+			&v1.Container{Env: nil},
 			nil,
 			[]v1.EnvVar{
 				{
@@ -74,7 +74,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"both-empty",
-			[]v1.EnvVar{},
+			&v1.Container{Env: []v1.EnvVar{}},
 			[]model.EnvVar{},
 			[]v1.EnvVar{
 				{
@@ -85,7 +85,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 		},
 		{
 			"no-overlap",
-			[]v1.EnvVar{
+			&v1.Container{Env: []v1.EnvVar{
 				{
 					Name:  "deployment",
 					Value: "value-from-deployment",
@@ -94,7 +94,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
 				},
-			},
+			}},
 			[]model.EnvVar{
 				{
 					Name:  "dev",
@@ -106,16 +106,12 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 			},
 			[]v1.EnvVar{
 				{
-					Name:  "CND_KUBERNETES_NAMESPACE",
-					Value: "cnd-namespace",
+					Name:  "deployment",
+					Value: "value-from-deployment",
 				},
 				{
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
-				},
-				{
-					Name:  "deployment",
-					Value: "value-from-deployment",
 				},
 				{
 					Name:  "dev",
@@ -125,11 +121,15 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 					Name:  "test",
 					Value: "true",
 				},
+				{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
 			},
 		},
 		{
 			"overlap",
-			[]v1.EnvVar{
+			&v1.Container{Env: []v1.EnvVar{
 				{
 					Name:  "deployment",
 					Value: "value-from-deployment",
@@ -138,7 +138,7 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 					Name:  "another-deployment",
 					Value: "another-value-from-deployment",
 				},
-			},
+			}},
 			[]model.EnvVar{
 				{
 					Name:  "dev",
@@ -155,16 +155,12 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 			},
 			[]v1.EnvVar{
 				{
-					Name:  "CND_KUBERNETES_NAMESPACE",
-					Value: "cnd-namespace",
+					Name:  "deployment",
+					Value: "value-from-deployment",
 				},
 				{
 					Name:  "another-deployment",
 					Value: "overriden-value-from-dev",
-				},
-				{
-					Name:  "deployment",
-					Value: "value-from-deployment",
 				},
 				{
 					Name:  "dev",
@@ -174,20 +170,24 @@ func Test_mergeEnvironmentVariables(t *testing.T) {
 					Name:  "test",
 					Value: "true",
 				},
+				{
+					Name:  "CND_KUBERNETES_NAMESPACE",
+					Value: "cnd-namespace",
+				},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := mergeEnvironmentVariables(tt.deployment, tt.dev, "cnd-namespace")
-			for i := range result {
-				if result[i].Name != tt.expected[i].Name {
-					t.Fatalf("failed to merge name. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", result[i].Name, tt.expected[i].Name, result, tt.expected)
+			mergeEnvironmentVariables(tt.container, tt.dev, "cnd-namespace")
+			for i, envvar := range tt.container.Env {
+				if envvar.Name != tt.expected[i].Name {
+					t.Fatalf("failed to merge name. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", envvar.Name, tt.expected[i].Name, tt.container.Env, tt.expected)
 				}
 
-				if result[i].Value != tt.expected[i].Value {
-					t.Fatalf("failed to merge value. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", result[i].Value, tt.expected[i].Value, result, tt.expected)
+				if envvar.Value != tt.expected[i].Value {
+					t.Fatalf("failed to merge value. '%s' != '%s'.\nActual\n%+v\nExpected\n%+v", envvar.Value, tt.expected[i].Value, tt.container.Env, tt.expected)
 				}
 			}
 


### PR DESCRIPTION
Fixes # cnd set empty values for variables using `valueFrom` instead of `value`.

## Proposed changes
- Keep the original list of variables untouched, just update the ones referenced by `cnd.yml`
