### PR TITLE
use filepath instead of path since it's OS independent

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
 	"github.com/cloudnativedevelopment/cnd/pkg/linguist"
@@ -46,7 +46,7 @@ func executeCreate(devPath string) error {
 	}
 
 	dev := linguist.GetDevConfig(languagesDiscovered[0])
-	dev.Swap.Deployment.Name = path.Base(root)
+	dev.Swap.Deployment.Name = filepath.Base(root)
 	marshalled, err := yaml.Marshal(dev)
 	if err != nil {
 		log.Info(err)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -192,5 +192,5 @@ func Wait() {
 }
 
 func getFlagPath() string {
-	return path.Join(config.GetCNDHome(), ".noanalytics")
+	return filepath.Join(config.GetCNDHome(), ".noanalytics")
 }

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -3,7 +3,7 @@ package analytics
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
@@ -25,7 +25,7 @@ func Test_isEnabled(t *testing.T) {
 		CNDHomePath: tmpdir,
 	})
 
-	analyticsFlag := path.Join(tmpdir, ".cnd", ".noanalytics")
+	analyticsFlag := filepath.Join(tmpdir, ".cnd", ".noanalytics")
 	if analyticsFlag != getFlagPath() {
 		t.Errorf("got %s expected %s", getFlagPath(), analyticsFlag)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 // These values will be stamped at build time
@@ -95,7 +95,7 @@ func GetCNDHome() string {
 		cndHome = overrideConfig.CNDHomePath
 	}
 
-	home := path.Join(cndHome, cndFolder)
+	home := filepath.Join(cndHome, cndFolder)
 
 	if err := os.MkdirAll(home, 0700); err != nil {
 		fmt.Printf("failed to create the home directory: %s\n", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/cloudnativedevelopment/cnd/pkg/model"
 )
 
 // These values will be stamped at build time
@@ -90,7 +92,8 @@ func GetCNDHome() string {
 		cndFolder = overrideConfig.CNDFolderName
 	}
 
-	var cndHome = os.Getenv("HOME")
+	cndHome := model.GetHomeDir()
+
 	if overrideConfig.CNDHomePath != "" {
 		cndHome = overrideConfig.CNDHomePath
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -13,7 +13,7 @@ func TestGetCNDHome(t *testing.T) {
 		config *Config
 	}{
 		{
-			"default", path.Join(os.Getenv("HOME"), ".cnd"), &Config{},
+			"default", filepath.Join(os.Getenv("HOME"), ".cnd"), &Config{},
 		},
 		{
 			"custom-path", "/tmp/foo/.cnd", &Config{CNDHomePath: "/tmp/foo"},

--- a/pkg/k8/client/client.go
+++ b/pkg/k8/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"k8s.io/client-go/kubernetes"
@@ -24,7 +24,7 @@ func Get(namespace string) (string, *kubernetes.Clientset, *rest.Config, string,
 		}
 	}
 
-	kubeconfig := path.Join(home, ".kube", "config")
+	kubeconfig := filepath.Join(home, ".kube", "config")
 	kubeconfigEnv := os.Getenv("KUBECONFIG")
 	if len(kubeconfigEnv) > 0 {
 		kubeconfig = kubeconfigEnv

--- a/pkg/k8/client/client.go
+++ b/pkg/k8/client/client.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
+
+	"github.com/cloudnativedevelopment/cnd/pkg/model"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -16,14 +17,7 @@ import (
 // If namespace is empty, it will use the default namespace configured.
 // If path is empty, it will use the default path configuration
 func Get(namespace string) (string, *kubernetes.Clientset, *rest.Config, string, error) {
-	home := os.Getenv("HOME")
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-	}
-
+	home := model.GetHomeDir()
 	kubeconfig := filepath.Join(home, ".kube", "config")
 	kubeconfigEnv := os.Getenv("KUBECONFIG")
 	if len(kubeconfigEnv) > 0 {

--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -3,7 +3,7 @@ package deployments
 import (
 	"encoding/json"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/log"
 	"github.com/cloudnativedevelopment/cnd/pkg/model"
@@ -135,7 +135,7 @@ func createInitSyncthingContainer(d *appsv1.Deployment, dev *model.Dev) {
 			}
 		}
 	}
-	source := path.Join(dev.Mount.Target, "*")
+	source := filepath.Join(dev.Mount.Target, "*")
 	initSyncthingContainer := apiv1.Container{
 		Name:  dev.GetCNDInitSyncContainer(),
 		Image: image,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cloudnativedevelopment/cnd/pkg/config"
 	"github.com/fatih/color"
@@ -60,7 +60,7 @@ func Init(level logrus.Level, actionID string) {
 		FullTimestamp: true,
 	})
 
-	logPath := path.Join(config.GetCNDHome(), fmt.Sprintf("%s%s", config.GetBinaryName(), ".log"))
+	logPath := filepath.Join(config.GetCNDHome(), fmt.Sprintf("%s%s", config.GetBinaryName(), ".log"))
 	rolling := getRollingLog(logPath)
 	fileLogger.SetOutput(rolling)
 	fileLogger.SetLevel(logrus.DebugLevel)

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -200,7 +200,7 @@ func LoadDev(b []byte) (*Dev, error) {
 	}
 
 	if strings.HasPrefix(dev.Mount.Source, "~/") {
-		home := os.Getenv("HOME")
+		home := GetHomeDir()
 		dev.Mount.Source = filepath.Join(home, dev.Mount.Source[2:])
 	}
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -213,10 +212,10 @@ func (dev *Dev) fixPath(originalPath string) {
 
 	if !filepath.IsAbs(dev.Mount.Source) {
 		if filepath.IsAbs(originalPath) {
-			dev.Mount.Source = path.Join(path.Dir(originalPath), dev.Mount.Source)
+			dev.Mount.Source = filepath.Join(filepath.Dir(originalPath), dev.Mount.Source)
 		} else {
 
-			dev.Mount.Source = path.Join(wd, path.Dir(originalPath), dev.Mount.Source)
+			dev.Mount.Source = filepath.Join(wd, filepath.Dir(originalPath), dev.Mount.Source)
 		}
 	}
 }

--- a/pkg/model/home.go
+++ b/pkg/model/home.go
@@ -9,7 +9,7 @@ import (
 func GetHomeDir() string {
 	home := os.Getenv("HOME")
 	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
 		if home == "" {
 			home = os.Getenv("USERPROFILE")
 		}

--- a/pkg/model/home.go
+++ b/pkg/model/home.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"os"
+	"runtime"
+)
+
+// GetHomeDir returns an OS-aware home dir
+func GetHomeDir() string {
+	home := os.Getenv("HOME")
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+	}
+
+	return home
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -43,7 +42,7 @@ type Service struct {
 }
 
 func getSTPath() string {
-	return path.Join(config.GetCNDHome(), ".state")
+	return filepath.Join(config.GetCNDHome(), ".state")
 }
 
 func load() (*Storage, error) {
@@ -206,7 +205,7 @@ func fixPath(originalPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(folder, originalPath), nil
+	return filepath.Join(folder, originalPath), nil
 }
 
 func newService(folder, host string) (Service, error) {
@@ -227,7 +226,7 @@ func getServiceFolder(fullName string) (string, error) {
 		return "", fmt.Errorf("invalid state file, please remove %s from %s manualy and try again", fullName, getSTPath())
 	}
 
-	return path.Join(config.GetCNDHome(), parts[0], parts[1]), nil
+	return filepath.Join(config.GetCNDHome(), parts[0], parts[1]), nil
 }
 
 // RemoveIfStale removes the entry from the state file if it's stale

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -35,7 +35,7 @@ func NewAPIClient() *http.Client {
 
 // GetFromAPI calls the syncthing API and returns the parsed json or an error
 func (s *Syncthing) GetFromAPI(url string) ([]byte, error) {
-	urlPath := path.Join(s.GUIAddress, url)
+	urlPath := filepath.Join(s.GUIAddress, url)
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s", urlPath), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -101,7 +100,7 @@ func NewSyncthing(namespace, deployment string, devList []*model.Dev, primary bo
 	s := &Syncthing{
 		APIKey:           "cnd",
 		binPath:          fullPath,
-		Home:             path.Join(config.GetCNDHome(), namespace, deployment),
+		Home:             filepath.Join(config.GetCNDHome(), namespace, deployment),
 		Name:             deployment,
 		DevList:          devList,
 		Namespace:        namespace,
@@ -169,15 +168,15 @@ func (s *Syncthing) initConfig() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path.Join(s.Home, configFile), buf.Bytes(), 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(s.Home, configFile), buf.Bytes(), 0700); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path.Join(s.Home, certFile), cert, 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(s.Home, certFile), cert, 0700); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path.Join(s.Home, keyFile), key, 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(s.Home, keyFile), key, 0700); err != nil {
 		return err
 	}
 
@@ -220,7 +219,7 @@ func (s *Syncthing) Run(ctx context.Context, wg *sync.WaitGroup) error {
 		"-home", s.Home,
 		"-no-browser",
 		"-verbose",
-		"-logfile", path.Join(s.Home, logFile),
+		"-logfile", filepath.Join(s.Home, logFile),
 	}
 
 	s.cmd = exec.Command(s.binPath, cmdArgs...) //nolint: gas, gosec
@@ -284,7 +283,7 @@ func (s *Syncthing) RemoveFolder() error {
 		return nil
 	}
 
-	parentDir := path.Dir(s.Home)
+	parentDir := filepath.Dir(s.Home)
 	if parentDir != "." {
 		empty, err := isDirEmpty(parentDir)
 		if err != nil {
@@ -372,7 +371,7 @@ func IsInstalled() bool {
 
 // GetInstallPath returns the expected install path for syncthing
 func GetInstallPath() string {
-	return path.Join(config.GetCNDHome(), getBinaryName())
+	return filepath.Join(config.GetCNDHome(), getBinaryName())
 }
 
 func getBinaryName() string {


### PR DESCRIPTION
Fixes #203 

## Proposed changes
- Use `filepath` instead of `path` when calculating file names and paths, since it's OS-aware. 
