### PR TITLE
Always pull dev container image

### DIFF
--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -73,6 +73,7 @@ func updateCndContainer(c *apiv1.Container, dev *model.Dev, namespace string) {
 	if dev.Swap.Deployment.Image != "" {
 		c.Image = dev.Swap.Deployment.Image
 	}
+	c.ImagePullPolicy = apiv1.PullAlways
 
 	if len(dev.Swap.Deployment.Command) > 0 {
 		c.Command = dev.Swap.Deployment.Command


### PR DESCRIPTION
It is a common use case to have mutable container images for development.
This PR always pulls the dev image to be conservative and avoid possible issues when a new container image with the same tag is generated.